### PR TITLE
Make it clearer that you need to set APIKEY for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ general interface to <http://data.openspending.org/>.
 Not on npm yet so you'll need to clone the code and then install:
 
     git clone https://github.com/openspending/os-upload
-    cd os-upload 
+    cd os-upload
     npm install .
 
 ### Run the app locally
@@ -28,6 +28,11 @@ Deploy to Heroku:
 
 ### Testing
 
+You'll need to set a valid OpenSpending API Key environment variable for the
+tests to work.
+
+    export APIKEY=....
+
 Run them with mocha:
 
     mocha test
@@ -35,11 +40,6 @@ Run them with mocha:
 Or the npm way:
 
     npm test
-
-You'll need to set a valid OpenSpending API Key environment variable for the
-tests to work.
-
-    export APIKEY=....
 
 ----
 
@@ -64,7 +64,7 @@ to the [OpenSpending Permission API][perms].
 * [ ] I want to see what is in the datastore (size, recent changes)
 * [ ] As a Admin I want to see what uploads have happened recently
 * [ ]As a OS sysadmin I want somewhere to archive all the datasets in
-  openspending so if our db fails we don’t lose everything 
+  openspending so if our db fails we don’t lose everything
 
 ## Overall Plan including File Layout in the DataStore (data.openspending.org)
 

--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ app.listen(app.get('port'), function() {
 });
 
 app.all('*', function(req, res, next) {
-  if (config.mode === 'testing' && config.apikey) {
+  if (config.mode === 'testing') {
     req.cookies.apikey = config.apikey;
   }
   next();

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,11 @@ var fs = require('fs')
   , datastore = require('../lib/datastore.js')
   ;
 
+if (config.apikey === null || typeof config.apikey === 'undefined') {
+  throw "ERROR: You must set the APIKEY environment variable to a valid " +
+        "OpenSpending API key when testing!\n";
+}
+
 var app = require('../app.js').app;
 
 var localBucket = config.s3.bucket;


### PR DESCRIPTION
Running `npm test` without setting the APIKEY environment variable now
at least tells you that this is what you need to do.

In addition, I've moved the instructions in the README before the
instructions that tell you how to run the tests.
